### PR TITLE
fix static files maybe

### DIFF
--- a/podcast/settings.py
+++ b/podcast/settings.py
@@ -138,7 +138,8 @@ STATICFILES_DIRS = [
 
 # Simplified static file serving.
 # https://warehouse.python.org/project/whitenoise/
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+# STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
 
 if os.environ.get('DEBUG', True) == 'False':
     DEBUG = False


### PR DESCRIPTION
for some reason, summernote broke static files,

so now, we're just pushing them up to s3 instead of using whitenoise :P